### PR TITLE
Rename to FlexID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Go STID: Short Time IDs
+# Go FlexID: Flexible IDs
 
-A Go library for generating short string IDs with a time and random component. Also referred to as "STIDs": **S**hort **T**ime **ID**s.
+A Go library for generating short, configurable string IDs with a time and random component.
+Also referred to as "FIDs": **F**lexible **ID**s.
 
 Useful for when you want to *guarantee* 0 collisions between two points in time, while minimizing collisions for
 generated IDs *within* that time.
@@ -13,19 +14,19 @@ May generate `J3GzHY02O6S`.
 
 ## Features ✨
 
-- **Short:** Generates compact IDs using configurable character sets (alphabets).
-- **Collision Resistant:** Cryptographically secure random suffix minimizes collision probability.
 - **Highly Configurable:**
   - Set your own **epoch** (start date/time).
   - Adjust the **tick size** (milliseconds, seconds, minutes, etc.).
   - Choose different **alphabets** (Base62, Base16 (hex), Base64URL, Crockford Base32, or custom).
   - Control the **length** of the random part. Reduce for shorter IDs, increase for greater collision resistance.
+- **Short:** Generates compact IDs using configurable character sets (alphabets).
+- **Collision Resistant:** Cryptographically secure random suffix minimizes collision probability.
 - **Easy to Use:** Get started with sensible defaults or create fine-tuned generators.
 
 ## Installation 🚀
 
 ```sh
-go get github.com/amterp/stid
+go get github.com/amterp/flexid
 ```
 
 ## Usage 🔨
@@ -35,10 +36,10 @@ go get github.com/amterp/stid
 You can use the default generator, which uses some sensible default settings.
 
 ```go
-import "github.com/amterp/stid"
+import fid "github.com/amterp/flexid"
 
-id := stid.MustGenerate()
-anotherId, err := stid.Generate()
+id := fid.MustGenerate()
+anotherId, err := fid.Generate()
 ```
 
 ### Advanced (Custom Settings)
@@ -46,17 +47,17 @@ anotherId, err := stid.Generate()
 You can create your own `Generator` by passing it your own `Config` object.
 
 ```go
-import "github.com/amterp/stid"
+import fid "github.com/amterp/flexid"
 
 // NewConfig creates with defaults.
 // You can then chain With methods to customize settings.
-config := stid.NewConfig().
-	WithTickSize(stid.Second).
+config := fid.NewConfig().
+	WithTickSize(fid.Second).
 	WithNumRandomChars(6).
-	WithAlphabet(stid.Base16LowerAlphabet)
+	WithAlphabet(fid.Base16LowerAlphabet)
 
 // Create the generator with the config.
-generator, err := stid.NewGenerator(config)
+generator, err := fid.NewGenerator(config)
 if err != nil {
     panic(err)
 }
@@ -130,19 +131,19 @@ Below are some examples of IDs generated with different settings.
 | Base-64, UNIX epoch, hour, 5 random chars                  | `B2TXxM3k1`         |
 | Base-16, UNIX epoch, millisecond, 6 random chars           | `19628e9e59adc559d` |
 
-## Why STID?
+## Why FlexIDs?
 
-There are alternatives like UUIDs, NanoIDs, ULIDs, etc, so what does STID offer over these?
+There are alternatives like UUIDs, NanoIDs, ULIDs, etc, so what do FIDs offer over these?
 
 - **Configurability:** Fine-tune the epoch, tick size, alphabet, and random suffix length to precisely balance ID length, sortability, and collision resistance for your specific needs.
   - Need short IDs for a system with a known limited lifespan? Adjust the epoch and tick size.
   - Need higher collision resistance within a tick? Increase the random length.
-- **Brevity:** By configuring the epoch and tick size appropriately, STID can often generate significantly shorter IDs than alternatives like ULID or UUID, while retaining chronological sortability.
+- **Brevity:** By configuring the epoch and tick size appropriately, FlexID can generate significantly shorter IDs than alternatives like ULID or UUID, while retaining chronological sortability.
 - **Simplicity:** The underlying concept (time prefix + random suffix) is straightforward and easy to reason about.
 
 ## Performance
 
-Generating STIDs is very fast! There's no state or locking -- they'll generate as fast as your CPU can go!
+Generating FIDs is very fast! There's no state or locking - they'll generate as fast as your CPU can go!
 
 Benchmarking on an Apple M2 Pro, I get ~235 nanoseconds / op, or around 4-5 million IDs per second.
 

--- a/dev.rsl
+++ b/dev.rsl
@@ -1,14 +1,31 @@
 #!/usr/bin/env rad
 ---
-Facilitates development & ops for stid.
+Facilitates development & ops for flexid.
 ---
 args:
     build b bool          # Enable to build.
     test t bool           # Enable to test.
     version v string = "" # Set to release a new version.
     amend a bool          # Enable to amend the previous commit.
+    push p bool           # Enable to push.
 
     version enum ["patch", "minor", "major"]
+
+resolve_version = fn():
+    _, tags = $!`git tag`
+    tags = split(tags[:-1], "\n")
+    tags = [replace(t, "v", "") for t in tags]
+    tags = [split(t, "\.") for t in tags]
+    major = sort([parse_int(t[0]) for t in tags])[-1]
+    minor = sort([parse_int(t[1]) for t in tags if parse_int(t[0]) == major])[-1]
+    patch = sort([parse_int(t[2]) for t in tags if parse_int(t[0]) == major and parse_int(t[1]) == minor])[-1]
+    if version == "patch":
+        version = "v{major}.{minor}.{patch + 1}"
+    else if version == "minor":
+        version = "v{major}.{minor + 1}.0"
+    else if version == "major":
+        version = "v{major + 1}.0.0"
+    return version
 
 if version or build:
     $!`go build`
@@ -25,25 +42,9 @@ if version:
     if not clean_before:
         print(red("Dirty git repo! Commit and try again."))
         exit(1)
-
-    // determine version
-    _, tags = $!`git tag`
-    tags = split(tags[:-1], "\n")
-    tags = [replace(t, "v", "") for t in tags]
-    tags = [split(t, "\.") for t in tags]
-    major = sort([parse_int(t[0]) for t in tags])[-1]
-    minor = sort([parse_int(t[1]) for t in tags if parse_int(t[0]) == major])[-1]
-    patch = sort([parse_int(t[2]) for t in tags if parse_int(t[0]) == major and parse_int(t[1]) == minor])[-1]
-    if version == "patch":
-        version = "v{major}.{minor}.{patch + 1}"
-    else if version == "minor":
-        version = "v{major}.{minor + 1}.0"
-    else if version == "major":
-        version = "v{major + 1}.0.0"
+    
+    version = resolve_version()
     print("Bumping to version:", green(version))
-    ////////////////////
-
-    _, branch  = $!`echo -n $(git branch --show-current)`
 
     if amend:
         confirm $!`git commit --amend --no-edit`
@@ -51,6 +52,13 @@ if version:
         confirm $!`git commit -m "Bump version to {version}"`
 
     confirm $!`git tag -a "{version}" -m "Bump version to {version}"`
+
+if version or push:
+    _, branch  = $!`echo -n $(git branch --show-current)`
     confirm $!`git push origin {branch} --tags`
 
 print(green("✅ Done!"))
+
+// todo rad
+// - RAD-271 allow return not as last stmt
+// - custom func definitions at bottom of file

--- a/flexid.go
+++ b/flexid.go
@@ -1,4 +1,4 @@
-package stid
+package flexid
 
 import (
 	"crypto/rand"
@@ -61,7 +61,7 @@ func init() {
 	var err error
 	defaultGenerator, err = NewGenerator(NewConfig())
 	if err != nil {
-		panic("stid: failed to initialize default generator: " + err.Error())
+		panic("flexid: failed to initialize default generator: " + err.Error())
 	}
 }
 
@@ -142,7 +142,7 @@ func NewGenerator(config Config) (*Generator, error) {
 func MustNewGenerator(config Config) *Generator {
 	generator, err := NewGenerator(config)
 	if err != nil {
-		panic("stid: failed to create generator: " + err.Error())
+		panic("flexid: failed to create generator: " + err.Error())
 	}
 	return generator
 }
@@ -191,7 +191,7 @@ func (g *Generator) Generate() (string, error) {
 // It panics if the internal default generator failed to initialize.
 func Generate() (string, error) {
 	if defaultGenerator == nil {
-		panic("stid: default generator not initialized")
+		panic("flexid: default generator not initialized")
 	}
 	return defaultGenerator.Generate()
 }
@@ -199,7 +199,7 @@ func Generate() (string, error) {
 func MustGenerate() string {
 	id, err := Generate()
 	if err != nil {
-		panic("stid: failed to generate TID: " + err.Error())
+		panic("flexid: failed to generate TID: " + err.Error())
 	}
 	return id
 }
@@ -207,7 +207,7 @@ func MustGenerate() string {
 func (g *Generator) MustGenerate() string {
 	id, err := g.Generate()
 	if err != nil {
-		panic("stid: failed to generate TID: " + err.Error())
+		panic("flexid: failed to generate TID: " + err.Error())
 	}
 	return id
 }

--- a/flexid_benchmark_test.go
+++ b/flexid_benchmark_test.go
@@ -1,15 +1,15 @@
-package stid_test
+package flexid_test
 
 import (
 	"testing"
 
-	"github.com/amterp/stid"
+	fid "github.com/amterp/flexid"
 )
 
 var sink string
 
 func BenchmarkDefaultGenerate(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		sink = stid.MustGenerate()
+		sink = fid.MustGenerate()
 	}
 }

--- a/flexid_test.go
+++ b/flexid_test.go
@@ -1,4 +1,4 @@
-package stid
+package flexid
 
 import (
 	"fmt"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/amterp/stid
+module github.com/amterp/flexid
 
 go 1.24.2


### PR DESCRIPTION
Posted this library on /r/golang and got feedback that I should change the name. Let's do it. 'FlexID' chosen because

1. It communicates the configurability of the library (one of the selling points).
2. Still makes for nice shorthand e.g. FIDs.